### PR TITLE
Server crash in housing area fixes.

### DIFF
--- a/src/scripts/common/aethernet/HousingAethernet.cpp
+++ b/src/scripts/common/aethernet/HousingAethernet.cpp
@@ -21,7 +21,8 @@ public:
   {
     player.playScene( eventId, 0, HIDE_HOTBAR | NO_DEFAULT_CAMERA, [this, eventId]( Entity::Player& player, const Event::SceneResult& result )
     {
-      auto& exdData = Common::Service< Sapphire::Data::ExdDataGenerated >::ref();
+      //auto& exdData = Common::Service< Sapphire::Data::ExdDataGenerated >::ref();
+      auto& exdData = *reinterpret_cast< Sapphire::Data::ExdDataGenerated* >( player.getExdData() );
 
       auto housingZone = std::dynamic_pointer_cast< HousingZone >( player.getCurrentTerritory() );
       if( !housingZone )
@@ -40,7 +41,8 @@ public:
       // moving a player inside an event will crash the game so we end it here
       player.eventFinish( eventId, 1 );
 
-      auto& playerMgr = Common::Service< Sapphire::World::Manager::PlayerMgr >::ref();
+      //auto& playerMgr = Common::Service< Sapphire::World::Manager::PlayerMgr >::ref();
+      auto& playerMgr = *reinterpret_cast< Sapphire::World::Manager::PlayerMgr* >( player.getPlayerMgr() );
       playerMgr.movePlayerToLandDestination( player, pHousingAethernet->level, housingZone->getWardNum() );
     } );
   }

--- a/src/scripts/common/eobj/HousingEstateEntrance.cpp
+++ b/src/scripts/common/eobj/HousingEstateEntrance.cpp
@@ -26,7 +26,8 @@ public:
       if( result.param2 != 1 )
         return;
 
-      auto& terriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
+      //auto& terriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
+      auto& terriMgr = *reinterpret_cast< Sapphire::World::Manager::TerritoryMgr* >( player.getTerritoryMgr() );
 
       auto zone = std::dynamic_pointer_cast< HousingZone >( player.getCurrentTerritory() );
       if( !zone )

--- a/src/world/Manager/PlayerMgr.cpp
+++ b/src/world/Manager/PlayerMgr.cpp
@@ -16,7 +16,8 @@ using namespace Sapphire::World::Manager;
 void Sapphire::World::Manager::PlayerMgr::movePlayerToLandDestination( Sapphire::Entity::Player& player, uint32_t landId, uint16_t param )
 {
   // check if we have one in the db first
-  auto& terriMgr = Common::Service< TerritoryMgr >::ref();
+  //auto& terriMgr = Common::Service< TerritoryMgr >::ref();
+  auto& terriMgr = *reinterpret_cast< Sapphire::World::Manager::TerritoryMgr* >( player.getTerritoryMgr() );
 
   Sapphire::TerritoryPtr destinationZone;
 

--- a/src/world/Manager/TerritoryMgr.cpp
+++ b/src/world/Manager/TerritoryMgr.cpp
@@ -665,14 +665,22 @@ bool Sapphire::World::Manager::TerritoryMgr::movePlayer( TerritoryPtr pZone, Sap
   // mark character as zoning in progress
   pPlayer->setLoadingComplete( false );
 
+  bool zoneChanged = true;
   if( pPlayer->getLastPing() != 0 && pPlayer->getCurrentTerritory() )
-    pPlayer->getCurrentTerritory()->removeActor( pPlayer );
+  {
+    zoneChanged = pPlayer->getCurrentTerritory()->getGuId() != pZone->getGuId();
+    if( zoneChanged )
+      pPlayer->getCurrentTerritory()->removeActor( pPlayer );
+  }
 
-  pPlayer->setCurrentZone( pZone );
-  pZone->pushActor( pPlayer );
+  if( zoneChanged )
+  {
+    pPlayer->setCurrentZone( pZone );
+    pZone->pushActor( pPlayer );
 
-  // map player to instanceId so it can be tracked.
-  m_playerIdToInstanceMap[ pPlayer->getId() ] = pZone->getGuId();
+    // map player to instanceId so it can be tracked.
+    m_playerIdToInstanceMap[ pPlayer->getId() ] = pZone->getGuId();
+  }
 
   pPlayer->sendZonePackets();
 

--- a/src/world/Manager/TerritoryMgr.cpp
+++ b/src/world/Manager/TerritoryMgr.cpp
@@ -681,6 +681,11 @@ bool Sapphire::World::Manager::TerritoryMgr::movePlayer( TerritoryPtr pZone, Sap
     // map player to instanceId so it can be tracked.
     m_playerIdToInstanceMap[ pPlayer->getId() ] = pZone->getGuId();
   }
+  else
+  {
+    pPlayer->removeFromInRange();
+    pPlayer->clearInRangeSet();
+  }
 
   pPlayer->sendZonePackets();
 


### PR DESCRIPTION
Since you have the workaround functions merged, here's a quick replacement of them so it can work when compiling with vs2019.